### PR TITLE
If the URL already contains a ?, add an & instead

### DIFF
--- a/Scripts/Main.js
+++ b/Scripts/Main.js
@@ -1,4 +1,4 @@
 document.querySelectorAll("a").forEach(link =>
 {
-    link.href = link.href.includes("wikipedia.org/") ? (link.href = link.href.includes("?useskin=vector") ? link.href : link.href + '?useskin=vector') : link.href;
+    link.href = link.href.includes("wikipedia.org/") ? (link.href = link.href.includes("useskin=vector") ? link.href : link.href + (link.href.includes("?") ? "&" : "?") + 'useskin=vector') : link.href;
 });


### PR DESCRIPTION
If the URL to a page already contains a ?, then adding another ? is incorrect, and an & should be added instead. As an example, the URL `https://en.wikipedia.org/w/index.php?title=Yeti_Airlines_Flight_691&action=edit?useskin=vector` is incorrect; it should be `https://en.wikipedia.org/w/index.php?title=Yeti_Airlines_Flight_691&action=edit&useskin=vector`.