### PR TITLE
Fix extension for case sensitive file systems

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,9 +15,9 @@
     }
   ],
   "icons": {
-    "16": "images/icon-16.png",
-    "32": "images/icon-32.png",
-    "48": "images/icon-48.png",
-    "128": "images/icon-128.png"
+    "16": "Images/icon-16.png",
+    "32": "Images/icon-32.png",
+    "48": "Images/icon-48.png",
+    "128": "Images/icon-128.png"
   }
 }


### PR DESCRIPTION
The extension could not be loaded on filesystems that are case sensitive.
![image](https://user-images.githubusercontent.com/1521321/213668585-9d9bf0fc-c3cd-47fa-81b6-950afde9d245.png)
